### PR TITLE
Enable generation of TypeScript typings

### DIFF
--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
-    "declaration": false,
+    "declaration": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
This enables typescript typings of the package, which will be picked up by TypeScript when it's consumed.

Is there any reason for this not being enabled? Tests locally shows this to just work.